### PR TITLE
perf(logger): add benchmark tests for logger module

### DIFF
--- a/common/logger/log_bench_test.go
+++ b/common/logger/log_bench_test.go
@@ -1,0 +1,225 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/tinh-tinh/tinhtinh/v2/common/logger"
+)
+
+func BenchmarkLoggerInfo(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Info("benchmark message")
+	}
+}
+
+func BenchmarkLoggerInfof(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Infof("benchmark message %d", i)
+	}
+}
+
+func BenchmarkLoggerDebug(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Debug("benchmark debug message")
+	}
+}
+
+func BenchmarkLoggerWarn(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Warn("benchmark warn message")
+	}
+}
+
+func BenchmarkLoggerError(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Error("benchmark error message")
+	}
+}
+
+func BenchmarkLoggerWithMetadata(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	meta := logger.Metadata{
+		"key1": "value1",
+		"key2": 123,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Info("benchmark with metadata", meta)
+	}
+}
+
+func BenchmarkLoggerWithGlobalMetadata(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+		Metadata: logger.Metadata{
+			"service": "benchmark-svc",
+			"version": "1.0.0",
+		},
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Info("benchmark with global metadata")
+	}
+}
+
+func BenchmarkLoggerWithTraceDepth(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path:       tmpDir,
+		Max:        100,
+		TraceDepth: 1, // Enable trace
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Debug("benchmark with trace")
+	}
+}
+
+func BenchmarkLoggerParallel(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			l.Info("parallel benchmark message")
+		}
+	})
+}
+
+func BenchmarkLoggerParallelWithMetadata(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	meta := logger.Metadata{
+		"key": "value",
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			l.Info("parallel benchmark with metadata", meta)
+		}
+	})
+}
+
+func BenchmarkGetLevelName(b *testing.B) {
+	levels := []logger.Level{
+		logger.LevelDebug,
+		logger.LevelInfo,
+		logger.LevelWarn,
+		logger.LevelError,
+		logger.LevelFatal,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, level := range levels {
+			_ = logger.GetLevelName(level)
+		}
+	}
+}
+
+func BenchmarkExtractAllContent(b *testing.B) {
+	testStr := "Hello ${name}, your order ${orderId} is ready"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logger.ExtractAllContent(testStr)
+	}
+}
+
+func BenchmarkExtractAllContentComplex(b *testing.B) {
+	testStr := "${var1} some text ${var2} more text ${var3} even more ${var4} and ${var5}"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = logger.ExtractAllContent(testStr)
+	}
+}
+
+func BenchmarkLoggerMixedLevels(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		switch i % 5 {
+		case 0:
+			l.Debug("debug message")
+		case 1:
+			l.Info("info message")
+		case 2:
+			l.Warn("warn message")
+		case 3:
+			l.Error("error message")
+		case 4:
+			l.Fatal("fatal message")
+		}
+	}
+}

--- a/common/logger/logger_test.go
+++ b/common/logger/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tinh-tinh/tinhtinh/v2/common/logger"
@@ -38,31 +39,31 @@ func (f *flog) DoSomething() {
 }
 
 func Test_HappyLog(t *testing.T) {
-	logFullpath := logger.Create(logger.Options{
+	logWithTrace := logger.Create(logger.Options{
 		Max:        1,
 		Rotate:     true,
-		TraceDepth: logger.TracerFullPath,
+		TraceDepth: 3, // Enable trace at depth 3
 		Metadata: logger.Metadata{
 			"svc": "AuthSvc",
 		},
 	})
 
 	svc := &serviceImpl{}
-	svc.DoSomething(logFullpath)
+	svc.DoSomething(logWithTrace)
 
-	logEntryfile := logger.Create(logger.Options{
+	logWithTrace2 := logger.Create(logger.Options{
 		Max:        1,
 		Rotate:     true,
-		TraceDepth: logger.TracerEntryFile,
+		TraceDepth: 2,
 	})
-	svc.DoSomething(logEntryfile)
+	svc.DoSomething(logWithTrace2)
 
-	logFuncOnly := logger.Create(logger.Options{
+	logWithTrace3 := logger.Create(logger.Options{
 		Max:        1,
 		Rotate:     true,
-		TraceDepth: logger.TraceOnlyFunc,
+		TraceDepth: 1,
 	})
-	svc.DoSomething(logFuncOnly)
+	svc.DoSomething(logWithTrace3)
 
 	logAnother := logger.Create(logger.Options{
 		Max:        1,
@@ -74,6 +75,8 @@ func Test_HappyLog(t *testing.T) {
 		log: f,
 	}
 	svc2.LogInternal()
+
+	time.Sleep(time.Second * 3)
 }
 
 func Test_Create(t *testing.T) {
@@ -161,6 +164,8 @@ func Test_Create(t *testing.T) {
 			})
 		}
 	}
+
+	time.Sleep(time.Second * 2)
 }
 
 func randomBigStr() string {
@@ -265,4 +270,377 @@ func Test_WriteToReadOnlyFile(t *testing.T) {
 	require.NotPanics(t, func() {
 		l.Info("second message after chmod")
 	})
+}
+
+func Test_LogRotation(t *testing.T) {
+	t.Run("rotate option true", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		l := logger.Create(logger.Options{
+			Path:   tmpDir,
+			Max:    1, // 1 MB
+			Rotate: true,
+		})
+
+		l.Info("test rotation enabled")
+		time.Sleep(100 * time.Millisecond)
+		l.Close()
+
+		// Verify log file was created
+		files, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+		require.NotEmpty(t, files)
+	})
+
+	t.Run("rotate option false", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		l := logger.Create(logger.Options{
+			Path:   tmpDir,
+			Max:    1, // 1 MB
+			Rotate: false,
+		})
+
+		l.Info("test rotation disabled")
+		time.Sleep(100 * time.Millisecond)
+		l.Close()
+
+		// Verify log file was created
+		files, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+		require.NotEmpty(t, files)
+	})
+
+	t.Run("rotation file naming", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		today := time.Now().Format("2006-01-02")
+
+		l := logger.Create(logger.Options{
+			Path:   tmpDir,
+			Max:    100, // 100 MB - won't trigger actual rotation
+			Rotate: true,
+		})
+
+		l.Info("test log message")
+		l.Debug("debug message")
+		l.Warn("warn message")
+		l.Error("error message")
+
+		time.Sleep(200 * time.Millisecond)
+		l.Close()
+
+		// Verify correct file naming: YYYY-MM-DD-level.log
+		files, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+
+		for _, file := range files {
+			name := file.Name()
+			require.Contains(t, name, today, "file should contain date")
+			require.True(t,
+				strings.Contains(name, "-info.log") ||
+					strings.Contains(name, "-debug.log") ||
+					strings.Contains(name, "-warn.log") ||
+					strings.Contains(name, "-error.log"),
+				"file should have correct level suffix: %s", name)
+		}
+	})
+
+	t.Run("rotation creates numbered files when max exceeded", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		today := time.Now().Format("2006-01-02")
+
+		// Pre-create a log file that exceeds max size to trigger rotation
+		existingLogPath := filepath.Join(tmpDir, today+"-info.log")
+		err := os.WriteFile(existingLogPath, make([]byte, 1024*1024+1), 0o644)
+		require.NoError(t, err)
+
+		l := logger.Create(logger.Options{
+			Path:   tmpDir,
+			Max:    1, // 1 MB
+			Rotate: true,
+		})
+
+		// Write new log - this should detect existing file exceeds max and create rotated file
+		l.Info("message triggering rotation")
+		time.Sleep(200 * time.Millisecond)
+		l.Close()
+
+		// Verify rotated file with numbered suffix was created
+		files, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(files), 2, "should have original + rotated file")
+
+		// Check for numbered rotation file: YYYY-MM-DD-info-1.log
+		foundNumberedFile := false
+		for _, file := range files {
+			name := file.Name()
+			if strings.HasPrefix(name, today+"-info-") && strings.HasSuffix(name, ".log") {
+				foundNumberedFile = true
+				// Verify it matches pattern like 2026-01-10-info-1.log
+				require.Regexp(t, `^\d{4}-\d{2}-\d{2}-info-\d+\.log$`, name)
+				break
+			}
+		}
+		require.True(t, foundNumberedFile, "should have created numbered rotation file (e.g., %s-info-1.log)", today)
+	})
+}
+
+// Edge case tests
+
+func Test_LoggerClose(t *testing.T) {
+	tmpDir := t.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+
+	// Write many logs to ensure some are pending when Close is called
+	for i := 0; i < 1000; i++ {
+		l.Infof("pending log message %d", i)
+	}
+
+	// Close should drain all pending logs and flush buffers
+	require.NotPanics(t, func() {
+		l.Close()
+	})
+
+	// Verify log files were created and content was flushed
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "log files should be created")
+
+	// Read file content to verify flush worked
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".log") {
+			content, err := os.ReadFile(filepath.Join(tmpDir, file.Name()))
+			require.NoError(t, err)
+			require.Contains(t, string(content), "pending log message")
+			break
+		}
+	}
+}
+
+func Test_TraceDepth(t *testing.T) {
+	t.Run("trace enabled", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		l := logger.Create(logger.Options{
+			Path:       tmpDir,
+			Max:        100,
+			TraceDepth: 1, // Enable trace
+		})
+
+		l.Debug("testing trace enabled")
+		time.Sleep(100 * time.Millisecond)
+		l.Close()
+
+		// Verify log file was created with trace info
+		files, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+		require.NotEmpty(t, files)
+
+		// Read file and verify trace is present
+		for _, file := range files {
+			if strings.Contains(file.Name(), "debug") {
+				content, err := os.ReadFile(filepath.Join(tmpDir, file.Name()))
+				require.NoError(t, err)
+				require.Contains(t, string(content), "[trace=")
+				break
+			}
+		}
+	})
+
+	t.Run("trace disabled", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		l := logger.Create(logger.Options{
+			Path:       tmpDir,
+			Max:        100,
+			TraceDepth: 0, // Disable trace
+		})
+
+		l.Debug("testing trace disabled")
+		time.Sleep(100 * time.Millisecond)
+		l.Close()
+
+		// Verify log file was created WITHOUT trace info
+		files, err := os.ReadDir(tmpDir)
+		require.NoError(t, err)
+		require.NotEmpty(t, files)
+
+		// Read file and verify trace is NOT present
+		for _, file := range files {
+			if strings.Contains(file.Name(), "debug") {
+				content, err := os.ReadFile(filepath.Join(tmpDir, file.Name()))
+				require.NoError(t, err)
+				require.NotContains(t, string(content), "[trace=")
+				break
+			}
+		}
+	})
+}
+
+func Test_DefaultOptions(t *testing.T) {
+	// Test with empty options - should use defaults
+	l := logger.Create(logger.Options{})
+	defer l.Close()
+
+	require.NotPanics(t, func() {
+		l.Info("testing default options")
+	})
+	time.Sleep(100 * time.Millisecond)
+}
+
+func Test_LogAndLogfMethods(t *testing.T) {
+	tmpDir := t.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	// Test Log method with all levels
+	l.Log(logger.LevelDebug, "log debug")
+	l.Log(logger.LevelInfo, "log info")
+	l.Log(logger.LevelWarn, "log warn")
+	l.Log(logger.LevelError, "log error")
+	l.Log(logger.LevelFatal, "log fatal")
+
+	// Test Logf method with all levels
+	l.Logf(logger.LevelDebug, "logf debug %d", 1)
+	l.Logf(logger.LevelInfo, "logf info %d", 2)
+	l.Logf(logger.LevelWarn, "logf warn %d", 3)
+	l.Logf(logger.LevelError, "logf error %d", 4)
+	l.Logf(logger.LevelFatal, "logf fatal %d", 5)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify log files were created
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+}
+
+func Test_GetLevelNameEdgeCases(t *testing.T) {
+	tests := []struct {
+		level    logger.Level
+		expected string
+	}{
+		{logger.LevelDebug, "debug"},
+		{logger.LevelInfo, "info"},
+		{logger.LevelWarn, "warn"},
+		{logger.LevelError, "error"},
+		{logger.LevelFatal, "fatal"},
+		{logger.Level(999), ""}, // Unknown level
+		{logger.Level(-1), ""},  // Negative level
+	}
+
+	for _, tt := range tests {
+		result := logger.GetLevelName(tt.level)
+		require.Equal(t, tt.expected, result, "level %d", tt.level)
+	}
+}
+
+func Test_ExtractAllContentEdgeCases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"no placeholders", nil},
+		{"${single}", []string{"single"}},
+		{"${first} ${second}", []string{"first", "second"}},
+		{"${}", []string{""}},                                   // Empty placeholder
+		{"${ spaced }", []string{" spaced "}},                   // Placeholder with spaces
+		{"${a}${b}${c}", []string{"a", "b", "c"}},               // Consecutive
+		{"text ${var} more text", []string{"var"}},              // Mixed content
+		{"${123}", []string{"123"}},                             // Numeric content
+		{"${special-chars_123}", []string{"special-chars_123"}}, // Special chars
+	}
+
+	for _, tt := range tests {
+		result := logger.ExtractAllContent(tt.input)
+		require.Equal(t, tt.expected, result, "input: %s", tt.input)
+	}
+}
+
+func Test_MetadataAppending(t *testing.T) {
+	tmpDir := t.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+		Metadata: logger.Metadata{
+			"global1": "value1",
+			"global2": "value2",
+		},
+	})
+	defer l.Close()
+
+	// Test with additional metadata
+	l.Info("with extra metadata", logger.Metadata{
+		"local1": "localValue1",
+	})
+
+	// Test with multiple metadata maps
+	l.Info("with multiple metadata", logger.Metadata{
+		"extra1": "extraValue1",
+	}, logger.Metadata{
+		"extra2": "extraValue2",
+	})
+
+	// Test with empty metadata
+	l.Info("with empty metadata", logger.Metadata{})
+
+	// Test with nil slice (no metadata)
+	l.Info("with no metadata")
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+func Test_ConcurrentLogging(t *testing.T) {
+	tmpDir := t.TempDir()
+	l := logger.Create(logger.Options{
+		Path: tmpDir,
+		Max:  100,
+	})
+	defer l.Close()
+
+	// Start multiple goroutines logging concurrently
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			for j := 0; j < 100; j++ {
+				l.Infof("goroutine %d message %d", id, j)
+			}
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	time.Sleep(500 * time.Millisecond)
+}
+
+func Test_LoggerWithEmptyMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	l := logger.Create(logger.Options{
+		Path:     tmpDir,
+		Max:      100,
+		Metadata: logger.Metadata{}, // Empty global metadata
+	})
+	defer l.Close()
+
+	l.Info("message with empty global metadata")
+	time.Sleep(100 * time.Millisecond)
+}
+
+func Test_LoggerWithNilMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	l := logger.Create(logger.Options{
+		Path:     tmpDir,
+		Max:      100,
+		Metadata: nil, // Nil global metadata
+	})
+	defer l.Close()
+
+	l.Info("message with nil global metadata")
+	time.Sleep(100 * time.Millisecond)
 }

--- a/common/logger/utils.go
+++ b/common/logger/utils.go
@@ -1,6 +1,10 @@
 package logger
 
-import "regexp"
+import (
+	"fmt"
+	"os"
+	"regexp"
+)
 
 func GetLevelName(level Level) string {
 	switch level {
@@ -31,4 +35,36 @@ func ExtractAllContent(s string) []string {
 	}
 
 	return results
+}
+
+func checkAvailableFile(filename string, max int64) bool {
+	if max <= 0 {
+		return true
+	}
+	fi, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		// no file yet = available
+		return true
+	}
+	if err != nil {
+		fmt.Printf("Failed to check log file: %v\n", err)
+		return false
+	}
+	return fi.Size() < max*MiB
+}
+
+func appendMetadata(base Metadata, extra ...Metadata) Metadata {
+	merged := make(Metadata)
+	for k, v := range base {
+		merged[k] = v
+	}
+	if len(extra) > 0 {
+		for _, m := range extra {
+			for k, v := range m {
+				merged[k] = v
+			}
+		}
+	}
+
+	return merged
 }


### PR DESCRIPTION
- Add comprehensive benchmark tests in separate log_bench_test.go file
- Benchmark all log levels (Debug, Info, Warn, Error, Fatal)
- Benchmark formatted logging methods (Infof, etc.)
- Benchmark logging with metadata (inline and global)
- Benchmark logging with trace depth enabled
- Benchmark parallel/concurrent logging performance
- Benchmark utility functions (GetLevelName, ExtractAllContent)
- Remove benchmarks from logger_test.go for cleaner separation