### PR TITLE
feat(logger): add JSON format option for log output

### DIFF
--- a/common/logger/log_bench_test.go
+++ b/common/logger/log_bench_test.go
@@ -223,3 +223,18 @@ func BenchmarkLoggerMixedLevels(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkLoggerJson(b *testing.B) {
+	tmpDir := b.TempDir()
+	l := logger.Create(logger.Options{
+		Path:   tmpDir,
+		Max:    100,
+		Format: logger.FormatJSON,
+	})
+	defer l.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Info("benchmark message")
+	}
+}

--- a/common/logger/utils.go
+++ b/common/logger/utils.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 )
@@ -53,15 +54,15 @@ func checkAvailableFile(filename string, max int64) bool {
 	return fi.Size() < max*MiB
 }
 
-func appendMetadata(base Metadata, extra ...Metadata) Metadata {
-	merged := make(Metadata)
+func appendMetadata(base Metadata, extra ...Metadata) []slog.Attr {
+	merged := []slog.Attr{}
 	for k, v := range base {
-		merged[k] = v
+		merged = append(merged, slog.Any(k, v))
 	}
 	if len(extra) > 0 {
 		for _, m := range extra {
 			for k, v := range m {
-				merged[k] = v
+				merged = append(merged, slog.Any(k, v))
 			}
 		}
 	}

--- a/middleware/logger/middleware.go
+++ b/middleware/logger/middleware.go
@@ -21,9 +21,13 @@ type MiddlewareOptions struct {
 	Rotate             bool
 	SeparateBaseStatus bool
 	// Max Size in MB of each file log. Default is infinity.
-	Max    int64
+	Max int64
+	// Format is the log message template format (e.g., Dev, Common, Combined).
 	Format string
-	Level  clogger.Level
+	// OutputFormat specifies the log output format (text or json).
+	// Uses clogger.FormatText or clogger.FormatJSON.
+	OutputFormat clogger.Format
+	Level        clogger.Level
 }
 
 type wrappedWriter struct {
@@ -63,11 +67,16 @@ func (w *wrappedWriter) WriteHeader(statusCode int) {
 // - ${content-length}: the Content-Length header of the response
 // - ${latency}: the latency of the request in milliseconds
 // - ${date}: the current date and time in the format 2006-01-02 15:04:05
+//
+// The OutputFormat option specifies the log output format:
+// - clogger.FormatText (default): key=value text format
+// - clogger.FormatJSON: JSON format
 func Handler(opt MiddlewareOptions) func(http.Handler) http.Handler {
 	logger := clogger.Create(clogger.Options{
 		Path:   opt.Path,
 		Rotate: opt.Rotate,
 		Max:    opt.Max,
+		Format: opt.OutputFormat,
 	})
 	level := opt.Level
 


### PR DESCRIPTION
- Add Format type with FormatText and FormatJSON constants to common/logger
- Implement slog-based JSON and text handlers via createHandler method
- Add toSlogLevel function to map custom levels to slog.Level
- Add OutputFormat option to middleware/logger for consistency
- Add comprehensive unit tests for JSON format feature
- Fix TraceDepth tests to match slog output format