### PR TITLE
refactor(core): replace Exports with Status field on provider

### DIFF
--- a/core/module.go
+++ b/core/module.go
@@ -67,7 +67,6 @@ type NewModuleOptions struct {
 	Imports     []Modules
 	Controllers []Controllers
 	Providers   []Providers
-	Exports     []Providers
 	Guards      []Guard
 	Middlewares []Middleware
 	Interceptor Interceptor
@@ -179,15 +178,6 @@ func initModule(module *DynamicModule, opt NewModuleOptions) {
 			continue
 		}
 		ct(module)
-	}
-
-	// Exports
-	for _, e := range opt.Exports {
-		if e == nil {
-			continue
-		}
-		provider := e(module)
-		provider.SetStatus(PUBLIC)
 	}
 }
 

--- a/core/module_test.go
+++ b/core/module_test.go
@@ -180,7 +180,6 @@ func Test_Nil(t *testing.T) {
 			Controllers: []core.Controllers{nil},
 			Providers:   []core.Providers{nil},
 			Imports:     []core.Modules{nil},
-			Exports:     []core.Providers{nil},
 			Guards:      []core.Guard{nil},
 			Middlewares: []core.Middleware{nil},
 		})
@@ -218,6 +217,7 @@ func Test_Import(t *testing.T) {
 				return sub + "hihi"
 			},
 			Inject: []core.Provide{SUB_PROVIDER},
+			Status: core.PUBLIC,
 		})
 		return s
 	}
@@ -226,7 +226,6 @@ func Test_Import(t *testing.T) {
 		parent := module.New(core.NewModuleOptions{
 			Imports:   []core.Modules{subModule},
 			Providers: []core.Providers{parentService},
-			Exports:   []core.Providers{parentService},
 		})
 
 		return parent

--- a/core/provider.go
+++ b/core/provider.go
@@ -24,8 +24,6 @@ const (
 
 type Factory func(param ...interface{}) interface{}
 
-type ProviderType string
-
 type Provider interface {
 	GetName() Provide
 	SetName(name Provide)
@@ -117,7 +115,8 @@ type ProviderOptions struct {
 	Factory Factory
 	// Providers that are injected with the provider.
 	Inject []Provide
-	Type   ProviderType
+	// Status of the provider. Default is PRIVATE.
+	Status ProvideStatus
 }
 
 type ProviderParams interface {
@@ -184,7 +183,7 @@ func InitProviders(module Module, opt ProviderOptions) Provider {
 	} else {
 		provider = &DynamicProvider{
 			Name:   opt.Name,
-			Status: PRIVATE,
+			Status: opt.Status,
 			Scope:  opt.Scope,
 		}
 		module.AppendDataProviders(provider)
@@ -192,6 +191,10 @@ func InitProviders(module Module, opt ProviderOptions) Provider {
 
 	if provider.GetScope() == "" {
 		provider.SetScope(module.GetScope())
+	}
+
+	if provider.GetStatus() == "" {
+		provider.SetStatus(PRIVATE)
 	}
 
 	// Handle transient

--- a/core/provider_test.go
+++ b/core/provider_test.go
@@ -14,8 +14,9 @@ import (
 
 func ChildProvider(module core.Module) core.Provider {
 	provider := module.NewProvider(core.ProviderOptions{
-		Name:  "child",
-		Value: "child",
+		Name:   "child",
+		Value:  "child",
+		Status: core.PUBLIC,
 	})
 	return provider
 }
@@ -24,7 +25,6 @@ func ChildModule(module core.Module) core.Module {
 	childModule := module.New(core.NewModuleOptions{
 		Scope:     core.Global,
 		Providers: []core.Providers{ChildProvider},
-		Exports:   []core.Providers{ChildProvider},
 	})
 
 	return childModule
@@ -278,12 +278,13 @@ func Test_AutoNameProvider(t *testing.T) {
 		Name string
 	}
 	service := func(module core.Module) core.Provider {
-		return module.NewProvider(&StructName{Name: "module"})
+		prd := module.NewProvider(&StructName{Name: "module"})
+		prd.SetStatus(core.PUBLIC)
+		return prd
 	}
 
 	module := core.NewModule(core.NewModuleOptions{
 		Providers: []core.Providers{service},
-		Exports:   []core.Providers{service},
 	})
 
 	structName := core.Inject[StructName](module)
@@ -306,12 +307,13 @@ func (ProviderRef) ProvideName() string {
 
 func Test_RefProvide(t *testing.T) {
 	service := func(module core.Module) core.Provider {
-		return module.NewProvider(&ProviderRef{Name: "module"})
+		prd := module.NewProvider(&ProviderRef{Name: "module"})
+		prd.SetStatus(core.PUBLIC)
+		return prd
 	}
 
 	module := core.NewModule(core.NewModuleOptions{
 		Providers: []core.Providers{service},
-		Exports:   []core.Providers{service},
 	})
 
 	providerRef := core.Inject[ProviderRef](module)
@@ -349,12 +351,13 @@ func Test_MustInject(t *testing.T) {
 		Name string
 	}
 	service := func(module core.Module) core.Provider {
-		return module.NewProvider(&StructName{Name: "module"})
+		prd := module.NewProvider(&StructName{Name: "module"})
+		prd.SetStatus(core.PUBLIC)
+		return prd
 	}
 
 	module := core.NewModule(core.NewModuleOptions{
 		Providers: []core.Providers{service},
-		Exports:   []core.Providers{service},
 	})
 
 	t.Run("success", func(t *testing.T) {


### PR DESCRIPTION
- Remove Exports field from NewModuleOptions and its initialization logic
- Add Status field to ProviderOptions (defaults to PRIVATE)
- Remove unused ProviderType type
- Update tests to set Status: PUBLIC directly on providers instead of using Exports